### PR TITLE
Support -DLUA_DIR flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ if(NOT Boost_FOUND)
 	find_package(Boost REQUIRED)
 endif()
 
+if(LUA_DIR)
+	set(ENV{LUA_DIR} "${LUA_DIR}")
+endif()
+
 if(NOT LUA_FOUND AND NOT LUA51_FOUND)
 	find_package(Lua51 REQUIRED)
 	set(LUA_INCLUDE_DIRS "${LUA_INCLUDE_DIR}")


### PR DESCRIPTION
Setting the environment variable LUA_DIR for a command in Windows is a PITA. This adds support for defining the location of the LUA_DIR from the command-line using Cmake's -D flag.

The effects using bash syntax are:

```
cmake .                           # LUA_DIR is undefined
LUA_DIR=foo cmake .               # LUA_DIR=foo
cmake -DLUA_DIR=bar .             # LUA_DIR=bar
LUA_DIR=foo cmake -DLUA_DIR=bar . # LUA_DIR=bar
```
