### PR TITLE
Added BOOST_NOEXCEPT_IF(false) to destructors

### DIFF
--- a/luabind/detail/call_function.hpp
+++ b/luabind/detail/call_function.hpp
@@ -243,7 +243,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_function_void_caller()
+				~proxy_function_void_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 

--- a/luabind/detail/call_function.hpp
+++ b/luabind/detail/call_function.hpp
@@ -79,7 +79,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_function_caller()
+				~proxy_function_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 

--- a/luabind/detail/call_member.hpp
+++ b/luabind/detail/call_member.hpp
@@ -233,7 +233,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_member_void_caller()
+				~proxy_member_void_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 

--- a/luabind/detail/call_member.hpp
+++ b/luabind/detail/call_member.hpp
@@ -70,7 +70,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_member_caller()
+				~proxy_member_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 


### PR DESCRIPTION
I added the BOOST_NOEXCEPT_IF(false) after destructors so that on C++11 compilers it will not call std_terminate and allow useful error messages. I also just noticed a typo in the third commit message but I don't know how to fix it (I don't think that it is possible to change commit messages easily).