### PR TITLE
Enable solution folders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,12 @@
 # Iowa State University HCI Graduate Program/VRAC
 
 cmake_minimum_required(VERSION 2.8)
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+	# We are the top-level project
+	set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+endif()
+
 set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
 project(LuaBind)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Iowa State University HCI Graduate Program/VRAC
 
 cmake_minimum_required(VERSION 2.8)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
 project(LuaBind)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,9 +56,11 @@ set(TESTS
 	yield)
 
 add_library(test_main STATIC main.cpp)
+set_target_properties(test_main PROPERTIES FOLDER "tests")
 
 foreach(test ${TESTS})
 	add_executable(test_${test} test_${test}.cpp)
+	set_target_properties(test_${test} PROPERTIES FOLDER "tests")
 	target_link_libraries(test_${test} test_main luabind)
 	add_test(NAME ${test} COMMAND test_${test})
 endforeach()
@@ -73,6 +75,7 @@ if(BUILD_TESTING)
 		configure_file(test_headercompile.cpp.in "${CMAKE_CURRENT_BINARY_DIR}/test_headercompile_${SHORTNAME}.cpp" @ONLY)
 
 		add_executable(test_headercompile_${SHORTNAME} "${CMAKE_CURRENT_BINARY_DIR}/test_headercompile_${SHORTNAME}.cpp")
+		set_target_properties(test_headercompile_${SHORTNAME} PROPERTIES FOLDER "tests/headercompile")
 		target_link_libraries(test_headercompile_${SHORTNAME} luabind)
 	endforeach()
 endif()


### PR DESCRIPTION
Folders are only enabled if luabind is the top-level project. This puts the tests and the headercompile tests into `tests` and `tests/headercompile` respectively.
