### PR TITLE
Add support for handling index operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Iowa State University HCI Graduate Program/VRAC
 
 cmake_minimum_required(VERSION 2.8)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
 project(LuaBind)
 

--- a/luabind/class.hpp
+++ b/luabind/class.hpp
@@ -589,7 +589,7 @@ namespace luabind
 			return this->virtual_def(
 				name, f, detail::null_type()
 			  , detail::null_type(), boost::mpl::true_());
-		}
+        }
 
 		// virtual functions
 		template<class F, class DefaultOrPolicies>
@@ -607,7 +607,57 @@ namespace luabind
 			return this->virtual_def(
 				name, fn, default_
 			  , policies, boost::mpl::false_());
-		}
+        }
+
+        template<class F>
+        class_& defaultGet(F f)
+        {
+            return this->virtual_def(
+                "__index", f, detail::null_type()
+                , detail::null_type(), boost::mpl::true_());
+        }
+
+        // virtual functions
+        template<class F, class DefaultOrPolicies>
+        class_& defaultGet(F fn, DefaultOrPolicies default_or_policies)
+        {
+            return this->virtual_def(
+                "__index", fn, default_or_policies, detail::null_type()
+                , LUABIND_MSVC_TYPENAME detail::is_policy_cons<DefaultOrPolicies>::type());
+        }
+
+        template<class F, class Default, class Policies>
+        class_& defaultGet(F fn, Default default_, Policies const& policies)
+        {
+            return this->virtual_def(
+                "__index", fn, default_
+                , policies, boost::mpl::false_());
+        }
+
+        template<class F>
+        class_& defaultSet(F f)
+        {
+            return this->virtual_def(
+                "__newindex", f, detail::null_type()
+                , detail::null_type(), boost::mpl::true_());
+        }
+
+        // virtual functions
+        template<class F, class DefaultOrPolicies>
+        class_& defaultSet(F fn, DefaultOrPolicies default_or_policies)
+        {
+            return this->virtual_def(
+                "__newindex", fn, default_or_policies, detail::null_type()
+                , LUABIND_MSVC_TYPENAME detail::is_policy_cons<DefaultOrPolicies>::type());
+        }
+
+        template<class F, class Default, class Policies>
+        class_& defaultSet(F fn, Default default_, Policies const& policies)
+        {
+            return this->virtual_def(
+                "__newindex", fn, default_
+                , policies, boost::mpl::false_());
+        }
 
 		template<BOOST_PP_ENUM_PARAMS(LUABIND_MAX_ARITY, class A)>
 		class_& def(constructor<BOOST_PP_ENUM_PARAMS(LUABIND_MAX_ARITY, A)> sig)

--- a/src/object_rep.cpp
+++ b/src/object_rep.cpp
@@ -130,6 +130,34 @@ namespace luabind { namespace detail
               lua_call(L, 2, 0);
               return 0;
           }
+          else if (lua_isnil(L, -1))
+          {
+              // If a metatable exists we need to use that
+              if (!lua_getmetatable(L, -2))
+              {
+                  // No metatable, push user value to the right position
+                  lua_pushvalue(L, -2);
+              }
+
+              // Value not known, check the __newindex function
+              lua_pushstring(L, "__newindex");
+              lua_rawget(L, -2);
+
+              if (!lua_isnil(L, -1))
+              {
+                  // We hava an index function, hopefully it's actually a function...
+                  lua_pushvalue(L, 1);
+                  lua_pushvalue(L, 2);
+                  lua_pushvalue(L, 3);
+                  lua_call(L, 3, 0);
+              }
+              else
+              {
+                  lua_pop(L, 1);
+              }
+              // Pop the table again
+              lua_pop(L, 1);
+          }
 
           lua_pop(L, 1);
 
@@ -171,6 +199,33 @@ namespace luabind { namespace detail
               lua_getupvalue(L, -1, 1);
               lua_pushvalue(L, 1);
               lua_call(L, 1, 1);
+          }
+          else if (lua_isnil(L, -1))
+          {
+              // We don't want to handle __finalize
+              if (lua_isstring(L, 2) && ! lua_isnumber(L, 2))
+              {
+                  if (!strcmp(lua_tostring(L, 2), "__finalize"))
+                  {
+                      return 1;
+                  }
+              }
+
+              // Value not known, check the __index function
+              lua_pushstring(L, "__index");
+              lua_rawget(L, -3);
+
+              if (!lua_isnil(L, -1))
+              {
+                  // We hava an index function
+                  lua_pushvalue(L, 1);
+                  lua_pushvalue(L, 2);
+                  lua_call(L, 2, 1);
+              }
+              else
+              {
+                  lua_pop(L, 1);
+              }
           }
 
           return 1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,9 +56,11 @@ set(TESTS
 	yield)
 
 add_library(test_main STATIC main.cpp)
+set_target_properties(test_main PROPERTIES FOLDER "tests")
 
 foreach(test ${TESTS})
 	add_executable(test_${test} test_${test}.cpp)
+	set_target_properties(test_${test} PROPERTIES FOLDER "tests")
 	target_link_libraries(test_${test} test_main luabind)
 	add_test(NAME ${test} COMMAND test_${test})
 endforeach()
@@ -73,6 +75,7 @@ if(BUILD_TESTING)
 		configure_file(test_headercompile.cpp.in "${CMAKE_CURRENT_BINARY_DIR}/test_headercompile_${SHORTNAME}.cpp" @ONLY)
 
 		add_executable(test_headercompile_${SHORTNAME} "${CMAKE_CURRENT_BINARY_DIR}/test_headercompile_${SHORTNAME}.cpp")
+		set_target_properties(test_headercompile_${SHORTNAME} PROPERTIES FOLDER "tests/headercompile")
 		target_link_libraries(test_headercompile_${SHORTNAME} luabind)
 	endforeach()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TESTS
 	held_type
 	implicit_cast
 	implicit_raw
+	index_operator
 	iterator
 	lua_classes
 	null_pointer

--- a/test/test_index_operator.cpp
+++ b/test/test_index_operator.cpp
@@ -1,0 +1,79 @@
+
+#include "test.hpp"
+#include <luabind/luabind.hpp>
+
+class indexable
+{
+public:
+    indexable() : val1(1), val2(2), prop(0)
+    {}
+
+    int val1;
+    int val2;
+
+    int prop;
+
+    int getVal(const char* x)
+    {
+        if (*x == 'a')
+        {
+            return val1;
+        }
+        return val2;
+    }
+
+    void setVal(const char* x, int v)
+    {
+        if (*x == 'a')
+        {
+            val1 = v;
+            return;
+        }
+        val2 = v;
+    }
+};
+
+indexable instance;
+indexable* get()
+{
+    return &instance;
+}
+
+void test_main(lua_State* L)
+{
+    using namespace luabind;
+
+    module(L)[
+        class_<indexable>("test")
+
+            .defaultGet(&indexable::getVal)
+            .defaultSet(&indexable::setVal)
+            
+            .def_readwrite("prop", &indexable::prop),
+            def("get", &get)
+    ];
+    DOSTRING(L, "x = get()\n");
+    TEST_CHECK(instance.val1 == 1);
+    TEST_CHECK(instance.val2 == 2);
+    TEST_CHECK(instance.prop == 0);
+
+    DOSTRING(L, "assert(x.a == 1)\n");
+    DOSTRING(L, "assert(x.b == 2)\n");
+
+    DOSTRING(L, "x.a = 5\n");
+    TEST_CHECK(instance.val1 == 5);
+    TEST_CHECK(instance.val2 == 2);
+    TEST_CHECK(instance.prop == 0);
+
+    DOSTRING(L, "x.b = 10\n");
+    TEST_CHECK(instance.val1 == 5);
+    TEST_CHECK(instance.val2 == 10);
+    TEST_CHECK(instance.prop == 0);
+
+    // Check if properties work
+    DOSTRING(L, "x.prop = 20\n");
+    TEST_CHECK(instance.val1 == 5);
+    TEST_CHECK(instance.val2 == 10);
+    TEST_CHECK(instance.prop == 20);
+}
+


### PR DESCRIPTION
It is currently not possible to intercept __index and __newindex calls for properties that are not yet defined, these changes should add support for that.
I am not familiar with the inner workings of this library and it is entirely possible that I broke something.