### PR TITLE
Mark destructors which can throw with noexcept(false)

### DIFF
--- a/luabind/detail/call_function.hpp
+++ b/luabind/detail/call_function.hpp
@@ -28,6 +28,7 @@
 
 #include <luabind/config.hpp>
 
+#include <boost/config.hpp> // BOOST_NOEXCEPT_IF
 #include <boost/mpl/if.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/mpl/or.hpp>
@@ -79,7 +80,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_function_caller()
+				~proxy_function_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 
@@ -243,7 +244,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_function_void_caller()
+				~proxy_function_void_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 

--- a/luabind/detail/call_member.hpp
+++ b/luabind/detail/call_member.hpp
@@ -33,6 +33,7 @@
 #include <luabind/detail/stack_utils.hpp>
 #include <luabind/detail/object.hpp> // TODO: REMOVE DEPENDENCY
 
+#include <boost/config.hpp> // BOOST_NOEXCEPT_IF
 #include <boost/tuple/tuple.hpp>
 
 #include <boost/preprocessor/control/if.hpp>
@@ -70,7 +71,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_member_caller()
+				~proxy_member_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 
@@ -233,7 +234,7 @@ namespace luabind
 					rhs.m_called = true;
 				}
 
-				~proxy_member_void_caller()
+				~proxy_member_void_caller() BOOST_NOEXCEPT_IF(false)
 				{
 					if (m_called) return;
 

--- a/luabind/detail/object.hpp
+++ b/luabind/detail/object.hpp
@@ -23,6 +23,7 @@
 #ifndef LUABIND_OBJECT_050419_HPP
 #define LUABIND_OBJECT_050419_HPP
 
+#include <boost/config.hpp> // BOOST_NOEXCEPT_IF
 #include <boost/implicit_cast.hpp> // detail::push()
 #include <boost/ref.hpp> // detail::push()
 #include <boost/mpl/bool.hpp> // value_wrapper_traits specializations
@@ -1118,7 +1119,7 @@ namespace adl
           other.value_wrapper = 0;
       }
 
-      ~call_proxy()
+      ~call_proxy() BOOST_NOEXCEPT_IF(false)
       {
           if (value_wrapper)
               call((detail::null_type*)0);


### PR DESCRIPTION
Destructors in C++11 are implicitly marked noexcept(true). It's generally considered a bad idea to throw from a destructor, but I figured this was an easier change to make than to re-architect the whole thing to not throw.

I've tried LUABIND_NO_EXCEPTIONS, but that seems to be a somewhat unmaintained branch.

Use BOOST_NOEXCEPT_IF so that in C++03 it evaluates to nothing.
