### PR TITLE
support const references of integers and numbers as arguments

### DIFF
--- a/luabind/detail/policy.hpp
+++ b/luabind/detail/policy.hpp
@@ -691,6 +691,12 @@ struct default_converter<T,
 	: integer_converter<T> {};
 
 template <typename T>
+struct default_converter<T const,
+	typename boost::enable_if<boost::is_integral<T> >::type
+	>
+	: integer_converter<T> {};
+
+template <typename T>
 struct default_converter<T const&,
 	typename boost::enable_if<boost::is_integral<T> >::type
 	>
@@ -724,6 +730,12 @@ struct number_converter
 // floating-point
 template <typename T>
 struct default_converter<T,
+	typename boost::enable_if<boost::is_floating_point<T> >::type
+	>
+	: number_converter<T> {};
+
+template <typename T>
+struct default_converter<T const,
 	typename boost::enable_if<boost::is_floating_point<T> >::type
 	>
 	: number_converter<T> {};

--- a/luabind/detail/policy.hpp
+++ b/luabind/detail/policy.hpp
@@ -690,6 +690,12 @@ struct default_converter<T,
 	>
 	: integer_converter<T> {};
 
+template <typename T>
+struct default_converter<T const&,
+	typename boost::enable_if<boost::is_integral<T> >::type
+	>
+	: integer_converter<T> {};
+
 // *********** converter for floating-point number types *****************
 template <typename QualifiedT>
 struct number_converter
@@ -718,6 +724,12 @@ struct number_converter
 // floating-point
 template <typename T>
 struct default_converter<T,
+	typename boost::enable_if<boost::is_floating_point<T> >::type
+	>
+	: number_converter<T> {};
+
+template <typename T>
+struct default_converter<T const&,
 	typename boost::enable_if<boost::is_floating_point<T> >::type
 	>
 	: number_converter<T> {};


### PR DESCRIPTION
Binding functions taking an argument with `const float&` type fails. This problem is found to be due to the lack of some template specializations.

Minimal complete example:

``` C++
extern "C"
{
    #include "lua.h"
    #include "lualib.h"
    #include "lauxlib.h"
}

#include <iostream>
#include <luabind/luabind.hpp>

void echofloat(const float &x)
{
    std::cout << x << std::endl;
}

extern "C" int init(lua_State* L)
{
    using namespace luabind;

    open(L);

    module(L)
    [
        def("echofloat", &echofloat)
    ];

    return 0;
}
```
